### PR TITLE
add info Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 pip install tk (pour installer tkinter dans l'environnement virtuel)
 
 sudo apt-get install python3-tk (Si Tkinter n'est pas inclus par défaut dans la version de Python,sous linux il faut utiliser cette commande)
+
+
+command d'installation Pillow: pip install Pillow
+Tkinter, par défaut, ne gère pas les formats .jpeg ou .png. Pillow permet de contourner cette limitation et de mieux gérer les formats populaires d'images, en plus d'offrir des fonctionnalités avancées comme le redimensionnement, la rotation, et plus encore.


### PR DESCRIPTION
Tkinter, par défaut, ne gère pas les formats .jpeg ou .png. Pillow permet de contourner cette limitation et de mieux gérer les formats populaires d'images, en plus d'offrir des fonctionnalités avancées comme le redimensionnement, la rotation, et plus encore.